### PR TITLE
Fixing katana-extraapps installation

### DIFF
--- a/packaging/archlinux/katana-extraapps/PKGBUILD
+++ b/packaging/archlinux/katana-extraapps/PKGBUILD
@@ -45,6 +45,7 @@ build() {
         -DENABLE_TESTING=OFF \
         -DCMAKE_SKIP_INSTALL_RPATH=ON \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib \
         -DWITH_KATIE=OFF
     make
 }


### PR DESCRIPTION
See this bug: https://github.com/fluxer/kde-extraapps/issues/3